### PR TITLE
update okhttp4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,12 +28,12 @@ dependencies {
     implementation project(':pandora-core')
 //    implementation "com.github.whataa:pandora:v2.0.1"
 //
-    implementation "androidx.appcompat:appcompat:1.0.0"
-    implementation "androidx.lifecycle:lifecycle-extensions:2.0.0-rc01"
+    implementation "androidx.appcompat:appcompat:1.0.2"
+    implementation "androidx.lifecycle:lifecycle-extensions:2.2.0-alpha02"
 //
-    implementation "androidx.room:room-runtime:2.0.0-rc01"
-    annotationProcessor "androidx.room:room-compiler:2.0.0-rc01"
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.2'
+    implementation "androidx.room:room-runtime:2.2.0-alpha01"
+    annotationProcessor "androidx.room:room-compiler:2.2.0-alpha01"
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation "androidx.browser:browser:1.0.0"
 
     implementation "com.squareup.retrofit2:retrofit:2.2.0"

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
             'MIN_SDK'        : 14,
             'TARGET_SDK'     : 28,
             'SUPPORT_LIB'    : '2.0.0-rc01',
-            'OKHTTP'         : '3.14.0'
+            'OKHTTP'         : '4.0.1'
     ]
 
     repositories {
@@ -14,7 +14,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip

--- a/pandora-core/build.gradle
+++ b/pandora-core/build.gradle
@@ -19,13 +19,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    api "androidx.appcompat:appcompat:1.0.0"
+    api "androidx.appcompat:appcompat:1.0.2"
     api "androidx.recyclerview:recyclerview:1.0.0"
-    api "com.google.android.material:material:1.0.0-rc01"
+    api "com.google.android.material:material:1.0.0"
     api "com.squareup.okhttp3:okhttp:${versions.OKHTTP}"
 }

--- a/pandora-core/src/main/java/tech/linjiang/pandora/network/okhttp3/internal/huc/OkHttpURLConnection.java
+++ b/pandora-core/src/main/java/tech/linjiang/pandora/network/okhttp3/internal/huc/OkHttpURLConnection.java
@@ -52,7 +52,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 import tech.linjiang.pandora.network.okhttp3.internal.JavaNetHeaders;
 import okhttp3.internal.Version;
-import okhttp3.internal.http.HttpDate;
 import okhttp3.internal.http.HttpHeaders;
 import okhttp3.internal.http.HttpMethod;
 import okhttp3.internal.http.StatusLine;
@@ -204,7 +203,7 @@ public final class OkHttpURLConnection extends HttpURLConnection implements Call
   @Override public String getHeaderField(String fieldName) {
     try {
       return fieldName == null
-          ? StatusLine.get(getResponse(true)).toString()
+          ? StatusLine.Companion.get(getResponse(true)).toString()
           : getHeaders().get(fieldName);
     } catch (IOException e) {
       return null;
@@ -224,7 +223,7 @@ public final class OkHttpURLConnection extends HttpURLConnection implements Call
   @Override public Map<String, List<String>> getHeaderFields() {
     try {
       return JavaNetHeaders.toMultimap(getHeaders(),
-          StatusLine.get(getResponse(true)).toString());
+          StatusLine.Companion.get(getResponse(true)).toString());
     } catch (IOException e) {
       return Collections.emptyMap();
     }
@@ -406,7 +405,7 @@ public final class OkHttpURLConnection extends HttpURLConnection implements Call
 
   private String defaultUserAgent() {
     String agent = getSystemProperty("http.agent", null);
-    return agent != null ? toHumanReadableAscii(agent) : Version.userAgent();
+    return agent != null ? toHumanReadableAscii(agent) : Version.userAgent;
   }
 
   /**
@@ -537,7 +536,7 @@ public final class OkHttpURLConnection extends HttpURLConnection implements Call
   @Override public void setIfModifiedSince(long newValue) {
     super.setIfModifiedSince(newValue);
     if (ifModifiedSince != 0) {
-      requestHeaders.set("If-Modified-Since", HttpDate.format(new Date(ifModifiedSince)));
+      requestHeaders.set("If-Modified-Since", new Date(ifModifiedSince));
     } else {
       requestHeaders.removeAll("If-Modified-Since");
     }


### PR DESCRIPTION
1. okhttp 更新到4.0.1
2. 更新了androidx的一些库版本
---
另外不知道你接受这样的版本管理写法,接受的话我增加一个commit
```groovy
ext.versions = [
            'COMPILE_SDK' : 28,
            'MIN_SDK'     : 14,
            'TARGET_SDK'  : 28,
            'SUPPORT_LIB' : '2.0.0-rc01',
            'OKHTTP'      : '4.0.1',
            'MATERIAL'    : '1.0.0',
            'RECYCLERVIEW': '1.0.0',
            'APPCOMPAT'   : '1.0.2',
            'GRADLE'      : '3.5.0-rc01',
            'MAVEN'       : '2.1'
    ]
    ext.deps = [
            okhttp      : "com.squareup.okhttp3:okhttp:${versions.OKHTTP}",
            material    : "com.google.android.material:material:${versions.MATERIAL}",
            recyclerview: "androidx.recyclerview:recyclerview:${versions.RECYCLERVIEW}",
            appcompat   : "androidx.appcompat:appcompat:${versions.APPCOMPAT}",
            gradle      : "com.android.tools.build:gradle:${versions.GRADLE}",
            maven       : "com.github.dcendents:android-maven-gradle-plugin:${versions.MAVEN}"
    ]
...

dependencies {
    implementation fileTree(dir: 'libs', include: ['*.jar'])
    api deps.appcompat
    api deps.recyclerview
    api deps.material
    api deps.okhttp
}
```